### PR TITLE
template: remove state

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,7 +1,6 @@
 - Start Date: YYYY-MM-DD
 - RFC PR: [#<PR>](https://github.com/inveniosoftware/rfcs/pull/<PR>)
 - Authors:
-- State: DRAFT
 
 # <RFC title>
 


### PR DESCRIPTION
I understand that state management is important. However, since we go through the process in CodiMD, then implement, then merge RFC. Most of the recently (and not so recently) merged RFCs are in state "draft". Does it stop being a draft when it is merged? i.e.

- PR = Draft
- Merged = Implemented

Currently, only 4 have a state != draft.